### PR TITLE
Update hasura graphql engine

### DIFF
--- a/apps/hasura-express/docker-compose.yml
+++ b/apps/hasura-express/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - jackson
 
   graphql-engine:
-    image: hasura/graphql-engine:v2.3.0
+    image: hasura/graphql-engine:v2.16.1
     depends_on:
       - postgres
     ports:

--- a/apps/hasura-nextjs/docker-compose.yml
+++ b/apps/hasura-nextjs/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - jackson
 
   graphql-engine:
-    image: hasura/graphql-engine:v2.12.0
+    image: hasura/graphql-engine:v2.16.1
     depends_on:
       - postgres
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1762,7 +1762,7 @@
       "devDependencies": {
         "@tailwindcss/forms": "0.5.3",
         "@types/node": "18.11.10",
-        "@types/react": "18.0.25",
+        "@types/react": "18.0.26",
         "autoprefixer": "10.4.13",
         "eslint": "8.28.0",
         "eslint-config-next": "13.0.5",
@@ -1770,6 +1770,17 @@
         "tailwindcss": "3.2.4",
         "ts-node": "10.9.1",
         "typescript": "4.9.4"
+      }
+    },
+    "apps/directory-sync-embedded/node_modules/@types/react": {
+      "version": "18.0.26",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz",
+      "integrity": "sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==",
+      "dev": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
       }
     },
     "apps/directory-sync-embedded/node_modules/next": {
@@ -2352,9 +2363,9 @@
         "ejs": "3.1.8",
         "express": "4.18.2",
         "express-session": "1.17.3",
-        "graphql-request": "5.0.0",
+        "graphql-request": "5.1.0",
         "http-errors": "2.0.0",
-        "jsonwebtoken": "8.5.1",
+        "jsonwebtoken": "9.0.0",
         "jwt-decode": "3.1.2",
         "morgan": "1.10.0",
         "node-fetch": "3.3.0",
@@ -2415,6 +2426,45 @@
         "ms": "2.0.0"
       }
     },
+    "apps/hasura-express/node_modules/jsonwebtoken": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash": "^4.17.21",
+        "ms": "^2.1.1",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "apps/hasura-express/node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "apps/hasura-express/node_modules/jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "apps/hasura-express/node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "apps/hasura-express/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -2458,7 +2508,7 @@
       },
       "devDependencies": {
         "@tailwindcss/forms": "0.5.3",
-        "@types/jsonwebtoken": "8.5.9",
+        "@types/jsonwebtoken": "9.0.0",
         "@types/node": "18.11.10",
         "@types/react": "18.0.26",
         "autoprefixer": "10.4.13",
@@ -2508,6 +2558,15 @@
         "subscriptions-transport-ws": {
           "optional": true
         }
+      }
+    },
+    "apps/hasura-nextjs/node_modules/@types/jsonwebtoken": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-mM4TkDpA9oixqg1Fv2vVpOFyIVLJjm5x4k0V+K/rEsizfjD7Tk7LKk3GTtbB7KCfP0FEHQtsZqFxYA0+sijNVg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "apps/hasura-nextjs/node_modules/@types/react": {
@@ -2869,7 +2928,7 @@
       "devDependencies": {
         "@tailwindcss/forms": "0.5.3",
         "autoprefixer": "10.4.13",
-        "postcss": "8.4.19",
+        "postcss": "8.4.20",
         "tailwindcss": "3.2.4"
       }
     },
@@ -2896,6 +2955,29 @@
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "apps/react/node_modules/postcss": {
+      "version": "8.4.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
+      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "apps/react/node_modules/react": {
@@ -20513,9 +20595,9 @@
       }
     },
     "node_modules/graphql-request": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.0.0.tgz",
-      "integrity": "sha512-SpVEnIo2J5k2+Zf76cUkdvIRaq5FMZvGQYnA4lUWYbc99m+fHh4CZYRRO/Ff4tCLQ613fzCm3SiDT64ubW5Gyw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.1.0.tgz",
+      "integrity": "sha512-0OeRVYigVwIiXhNmqnPDt+JhMzsjinxHE7TVy3Lm6jUzav0guVcL0lfSbi6jVTRAxcbwgyr6yrZioSHxf9gHzw==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "cross-fetch": "^3.1.5",
@@ -48017,7 +48099,7 @@
         "@boxyhq/saml-jackson": "1.4.0",
         "@tailwindcss/forms": "0.5.3",
         "@types/node": "18.11.10",
-        "@types/react": "18.0.25",
+        "@types/react": "18.0.26",
         "autoprefixer": "10.4.13",
         "classnames": "2.3.2",
         "eslint": "8.28.0",
@@ -48032,6 +48114,17 @@
         "typescript": "4.9.4"
       },
       "dependencies": {
+        "@types/react": {
+          "version": "18.0.26",
+          "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz",
+          "integrity": "sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==",
+          "dev": true,
+          "requires": {
+            "@types/prop-types": "*",
+            "@types/scheduler": "*",
+            "csstype": "^3.0.2"
+          }
+        },
         "next": {
           "version": "13.1.1",
           "resolved": "https://registry.npmjs.org/next/-/next-13.1.1.tgz",
@@ -51026,9 +51119,9 @@
       "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw=="
     },
     "graphql-request": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.0.0.tgz",
-      "integrity": "sha512-SpVEnIo2J5k2+Zf76cUkdvIRaq5FMZvGQYnA4lUWYbc99m+fHh4CZYRRO/Ff4tCLQ613fzCm3SiDT64ubW5Gyw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.1.0.tgz",
+      "integrity": "sha512-0OeRVYigVwIiXhNmqnPDt+JhMzsjinxHE7TVy3Lm6jUzav0guVcL0lfSbi6jVTRAxcbwgyr6yrZioSHxf9gHzw==",
       "requires": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "cross-fetch": "^3.1.5",
@@ -51250,9 +51343,9 @@
         "ejs": "3.1.8",
         "express": "4.18.2",
         "express-session": "1.17.3",
-        "graphql-request": "5.0.0",
+        "graphql-request": "5.1.0",
         "http-errors": "2.0.0",
-        "jsonwebtoken": "8.5.1",
+        "jsonwebtoken": "9.0.0",
         "jwt-decode": "3.1.2",
         "morgan": "1.10.0",
         "node-fetch": "3.3.0",
@@ -51309,6 +51402,43 @@
             }
           }
         },
+        "jsonwebtoken": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+          "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+          "requires": {
+            "jws": "^3.2.2",
+            "lodash": "^4.17.21",
+            "ms": "^2.1.1",
+            "semver": "^7.3.8"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.3",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+              "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+            }
+          }
+        },
+        "jwa": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+          "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+          "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+          "requires": {
+            "jwa": "^1.4.1",
+            "safe-buffer": "^5.0.1"
+          }
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -51332,7 +51462,7 @@
         "@apollo/client": "3.7.3",
         "@skillrecordings/next-auth-hasura-adapter": "0.0.2",
         "@tailwindcss/forms": "0.5.3",
-        "@types/jsonwebtoken": "8.5.9",
+        "@types/jsonwebtoken": "9.0.0",
         "@types/node": "18.11.10",
         "@types/react": "18.0.26",
         "autoprefixer": "10.4.13",
@@ -51368,6 +51498,15 @@
             "ts-invariant": "^0.10.3",
             "tslib": "^2.3.0",
             "zen-observable-ts": "^1.2.5"
+          }
+        },
+        "@types/jsonwebtoken": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+          "integrity": "sha512-mM4TkDpA9oixqg1Fv2vVpOFyIVLJjm5x4k0V+K/rEsizfjD7Tk7LKk3GTtbB7KCfP0FEHQtsZqFxYA0+sijNVg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
           }
         },
         "@types/react": {
@@ -58520,7 +58659,7 @@
         "@types/react": "18.0.25",
         "@types/react-dom": "18.0.10",
         "autoprefixer": "10.4.13",
-        "postcss": "8.4.19",
+        "postcss": "8.4.20",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-router-dom": "6.6.1",
@@ -58544,6 +58683,16 @@
           "version": "10.0.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
           "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+        },
+        "postcss": {
+          "version": "8.4.20",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
+          "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+          "requires": {
+            "nanoid": "^3.3.4",
+            "picocolors": "^1.0.0",
+            "source-map-js": "^1.0.2"
+          }
         },
         "react": {
           "version": "18.2.0",


### PR DESCRIPTION
Old docker image `hasura/graphql-engine:v2.12.0` seems non-existent now. Pull fails with error. This change uses the latest version.